### PR TITLE
Fix(hyunwoo/calendar): 달력페이지 오늘날짜 표시부분 가운데정렬

### DIFF
--- a/src/styles/Club/Home/Schedule/Table.module.scss
+++ b/src/styles/Club/Home/Schedule/Table.module.scss
@@ -19,6 +19,8 @@
   border-radius: 50%;
   width: 19px;
   height: 18px;
+  display: flex;
+  align-items: center;
 }
 
 .scheduleSpan {


### PR DESCRIPTION
(Before)
![image](https://user-images.githubusercontent.com/83463918/140240042-18c658b7-7ad6-4eb2-9238-19ecc6f74e01.png)

(After)
![image](https://user-images.githubusercontent.com/83463918/140240065-1350c30b-a43e-46fb-9e43-720e161331f4.png)

